### PR TITLE
enable Let's encrypt

### DIFF
--- a/infra/traefik/dynamic/https.yaml
+++ b/infra/traefik/dynamic/https.yaml
@@ -1,4 +1,0 @@
-tls:
-  certificates:
-    - certFile: /etc/pki/www/fullchain.cer
-      keyFile: /etc/pki/www/www.nopass.key

--- a/infra/traefik/traefik.yaml
+++ b/infra/traefik/traefik.yaml
@@ -20,6 +20,13 @@ entryPoints:
     address: ":80"
     http:
       tls: false
+certificatesResolvers:
+  main:
+    acme:
+      email: hpcs-admin@hpcs.cs.tsukuba.ac.jp
+      storage: /etc/pki/www/acme.json
+      certificatesDuration: 2160
+      tlsChallenge: {}
 providers:
   file:
     directory: /etc/traefik/dynamic


### PR DESCRIPTION
Traefikでwebサービスを暗号化します。[参考](https://doc.traefik.io/traefik/user-guides/docker-compose/acme-tls/)

ACMEチャレンジはTLSを選択しました。これで上手く動くかはあんまり自信ないですが、とりあえずやってみようかなと