### PR TITLE
fix: use current year for copyright notice

### DIFF
--- a/src/layouts/base/parts/Footer.astro
+++ b/src/layouts/base/parts/Footer.astro
@@ -1,9 +1,9 @@
 ---
-
+const currentYear = new Date().getFullYear()
 ---
 
 <footer>
-  © 2023 High Performance Computing System Laboratory (HPCS Lab.), hpcs-web
+  © {currentYear} High Performance Computing System Laboratory (HPCS Lab.), hpcs-web
   [at] hpcs.cs.tsukuba.ac.jp
 </footer>
 


### PR DESCRIPTION
フッタの年が`2023`とハードコードされていたので、現在（ビルド時点）の年が表示されるようにします。