### PR TITLE
style: accept narrower viewport for desktop

### DIFF
--- a/src/layouts/base/parts/header/desktop/Nav.astro
+++ b/src/layouts/base/parts/header/desktop/Nav.astro
@@ -90,7 +90,7 @@ const lastPage = pages[pages.length - 1];
     width: max-content;
   }
 
-  .nav-index-link-wrapper a {
+  .nav-index {
     padding: 0.5em;
   }
 

--- a/src/layouts/base/parts/header/desktop/Nav.astro
+++ b/src/layouts/base/parts/header/desktop/Nav.astro
@@ -78,7 +78,7 @@ const lastPage = pages[pages.length - 1];
     flex-direction: row;
     align-items: center;
     height: 100%;
-    gap: 2rem;
+    gap: 1rem;
     padding-inline-end: 2rem;
   }
 

--- a/src/layouts/base/parts/header/index.astro
+++ b/src/layouts/base/parts/header/index.astro
@@ -158,7 +158,7 @@ import { pages } from "./sitemap";
     padding-right: 1rem;
   }
 
-  @container (min-width: 60rem) {
+  @container (min-width: 50rem) {
     .desktop-nav {
       display: unset;
     }

--- a/src/layouts/base/parts/header/index.astro
+++ b/src/layouts/base/parts/header/index.astro
@@ -33,7 +33,7 @@ import { pages } from "./sitemap";
     addToggleEventListener: (handler: ToggleEventHandler) => void;
   };
 
-  customElements.whenDefined("humburger-button").then(() => {
+  customElements.whenDefined("hamburger-button").then(() => {
     const drawerToggleButton = document.getElementById(
       "drawer-toggle-button"
     ) as HamburgerButton | null;

--- a/src/layouts/base/parts/header/mobile/HamburgerButton.astro
+++ b/src/layouts/base/parts/header/mobile/HamburgerButton.astro
@@ -4,16 +4,16 @@ interface Props {
 }
 ---
 
-<humburger-button id={Astro.props.id}>
+<hamburger-button id={Astro.props.id}>
   <button class:list={["root"]}>
     <div class:list={["top", "bar"]}></div>
     <div class:list={["middle", "bar"]}></div>
     <div class:list={["bottom", "bar"]}></div>
   </button>
-</humburger-button>
+</hamburger-button>
 
 <script>
-  export class HumburgerButton extends HTMLElement {
+  export class HamburgerButton extends HTMLElement {
     opened: boolean;
     toggleEventListeners: ((opened: boolean) => void)[];
 
@@ -56,7 +56,7 @@ interface Props {
     }
   }
 
-  customElements.define("humburger-button", HumburgerButton);
+  customElements.define("hamburger-button", HamburgerButton);
 </script>
 
 <style>


### PR DESCRIPTION
デスクトップでも、ウィンドウを十分大きくしないとハンバーガーメニューになってしまって少し使いにくかったので、メディアクエリの条件を緩和してみました。

あと、ヘッダのメニューがリンクかどうかでpaddingが変わってしまっていたので、それも修正しました。

### Before
![Screenshot from 2024-03-28 16-55-27](https://github.com/HPCSLab/web/assets/1425259/2fca8a34-a772-4986-a167-1669e02e2586)
![Screenshot from 2024-03-28 16-55-20](https://github.com/HPCSLab/web/assets/1425259/b35a6083-c06f-46c0-9804-87bce66f16cc)

### After
![Screenshot from 2024-03-28 16-57-03](https://github.com/HPCSLab/web/assets/1425259/7442fcd0-272b-4171-9fb5-ea255ec81fad)
![Screenshot from 2024-03-28 16-57-06](https://github.com/HPCSLab/web/assets/1425259/6e5bf54c-25cd-41a9-91e0-f1168cd017c9)
