### PR TITLE
prevent automerge on docker tag

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
+      "matchDatasources": ["npm", "github-actions"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
`npm`と`github-actions`でのみautomergeを許可します。dockerの場合はminor changeであってもphpのように破壊的な変更となる恐れがあり、かつGitHub actionsでの自動テストが設定されていないので手動で対応したいためです。