### PR TITLE
卒検配属ページの教員名のリンクを教員個人ページへ変更

### DIFF
--- a/src/components/pages/bachelor/TeamCard.astro
+++ b/src/components/pages/bachelor/TeamCard.astro
@@ -41,7 +41,7 @@ const { team, href } = Astro.props;
                     facultyRef.id
                   );
                   return (
-                    <a href={`/members/${facultyRef.id}`} class="faculty-name">
+                    <a href={`/~${facultyRef.id}`} class="faculty-name">
                       {faculty.data.name
                         ? faculty.data.name
                         : faculty.data.eng_name}


### PR DESCRIPTION
これは

- #36 

を解決します。ただメンバー個人のページを作成するのもありかもしれません