### PR TITLE
Add an additional link to the bachelor page

### DIFF
--- a/src/layouts/base/parts/header/desktop/Nav.astro
+++ b/src/layouts/base/parts/header/desktop/Nav.astro
@@ -2,6 +2,7 @@
 import type { IndexPage } from "../sitemap";
 import Box from "@components/layout/box/box.astro";
 import TextWithIcon from "@components/atom/TextWithIcon.astro";
+import { bachelorPage } from "../sitemap";
 
 interface Props {
   pages: IndexPage[];
@@ -69,6 +70,11 @@ const lastPage = pages[pages.length - 1];
         </li>
       ))
     }
+    <li class="nav-index strong">
+      <Box p="0.5rem">
+        <a href={bachelorPage.url}>卒研配属情報</a>
+      </Box>
+    </li>
   </ul>
 </nav>
 
@@ -99,6 +105,11 @@ const lastPage = pages[pages.length - 1];
     position: relative;
     z-index: 1;
     height: 100%;
+  }
+
+  .nav-index.strong {
+    background-color: var(--color-triadic-2);
+    color: white;
   }
 
   @keyframes show-drawer {
@@ -170,5 +181,21 @@ const lastPage = pages[pages.length - 1];
 
   .nav-wrapper {
     height: 100%;
+  }
+
+  .strong-link {
+    background-color: white;
+    width: fit-content;
+    padding: 0.4rem;
+    color: var(--color-primary);
+    border-radius: 0.5rem;
+    transition: all 0.1s linear;
+    border: 1px solid var(--color-primary);
+  }
+
+  .strong-link:hover {
+    background-color: var(--color-primary);
+    border: 1px solid var(--color-primary);
+    color: white;
   }
 </style>

--- a/src/layouts/base/parts/header/index.astro
+++ b/src/layouts/base/parts/header/index.astro
@@ -158,7 +158,7 @@ import { pages } from "./sitemap";
     padding-right: 1rem;
   }
 
-  @container (min-width: 50rem) {
+  @container (min-width: 55rem) {
     .desktop-nav {
       display: unset;
     }

--- a/src/layouts/base/parts/header/mobile/Nav.astro
+++ b/src/layouts/base/parts/header/mobile/Nav.astro
@@ -2,6 +2,7 @@
 import FullscreenNavIndexAcordion from "./NavIndexAcordion.astro";
 import FullscreenNavIndexLink from "./NavIndexLink.astro";
 import type { IndexPage } from "../sitemap";
+import { bachelorPage } from "../sitemap";
 
 interface Props {
   id?: string;
@@ -10,6 +11,11 @@ interface Props {
 ---
 
 <nav id={Astro.props.id}>
+  <div class="root">
+    <h2>
+      <a href={bachelorPage.url} class="strong-link">卒研配属情報</a>
+    </h2>
+  </div>
   {
     Astro.props.sitemap.map((index) => (
       <div>
@@ -36,5 +42,33 @@ interface Props {
 
   .show {
     background-color: rgba(255, 255, 255, 0.9);
+  }
+
+  .strong-link {
+    background-color: var(--color-triadic-2);
+    width: fit-content;
+    padding: 0.4rem;
+    font-weight: bolder;
+    color: var(--color-inverted-text-strong);
+    border-radius: 0.3rem;
+    transition: all 0.1s linear;
+    border: 2px solid var(--color-triadic-2);
+  }
+
+  .strong-link:hover {
+    border: 2px solid var(--color-triadic-2);
+    background-color: white;
+    color: var(--color-triadic-2);
+  }
+
+  h2 {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    border-bottom: 0.5px solid var(--color-text-weak);
+    height: 4rem;
+    padding-left: 1rem;
   }
 </style>

--- a/src/layouts/base/parts/header/sitemap.ts
+++ b/src/layouts/base/parts/header/sitemap.ts
@@ -28,6 +28,13 @@ export type AcordionIndex = {
 
 export type IndexPage = JustLinkIndex | AcordionIndex;
 
+export const bachelorPage : JustLinkIndex = {
+  title: "卒研配属",
+  url: "/bachelor",
+  hasChildren: false,
+  icon: "material-symbols:chat-info-outline-rounded",
+}
+
 const teamPages = (await getCollection("team")).map((team) => ({
   title: team.data.name,
   url: `/teams/${team.slug}`,
@@ -40,11 +47,7 @@ export const pages: IndexPage[] = [
     hasChildren: true,
     icon: "material-symbols:team-dashboard-outline",
     children: [
-      {
-        title: "卒研配属",
-        url: "/bachelor",
-        icon: "material-symbols:chat-info-outline-rounded",
-      },
+      bachelorPage,
       ...teamPages,
     ],
   },

--- a/src/layouts/base/parts/header/sitemap.ts
+++ b/src/layouts/base/parts/header/sitemap.ts
@@ -28,12 +28,12 @@ export type AcordionIndex = {
 
 export type IndexPage = JustLinkIndex | AcordionIndex;
 
-export const bachelorPage : JustLinkIndex = {
+export const bachelorPage: JustLinkIndex = {
   title: "卒研配属",
   url: "/bachelor",
   hasChildren: false,
   icon: "material-symbols:chat-info-outline-rounded",
-}
+};
 
 const teamPages = (await getCollection("team")).map((team) => ({
   title: team.data.name,
@@ -46,10 +46,7 @@ export const pages: IndexPage[] = [
     title: "Teams",
     hasChildren: true,
     icon: "material-symbols:team-dashboard-outline",
-    children: [
-      bachelorPage,
-      ...teamPages,
-    ],
+    children: [bachelorPage, ...teamPages],
   },
   {
     title: "Members",


### PR DESCRIPTION
メニューに卒研情報を足してみました．旧 WordPress 版のようにサイドバーとするほうがデザイン的にはよさそうでしたが，レイアウト変更が結構たいへんそうだったのでナビゲーションをいじることにしました．とはいえ，モバイルと PC の双方のデザインを修正する必要があったのであんまりきれいな変更ではないかもと思っています．議論の余地めっちゃあると思うのでメンテ可能そうならばマージおねがいします．

![image](https://github.com/user-attachments/assets/e6203934-964f-4dc2-9dea-7c417c5b3bb2)
![image](https://github.com/user-attachments/assets/7ffa0ddd-b802-421f-8d50-32e33bd77bad)
