### PR TITLE
Remove bachelor page

### DIFF
--- a/src/layouts/base/parts/header/desktop/Nav.astro
+++ b/src/layouts/base/parts/header/desktop/Nav.astro
@@ -3,6 +3,7 @@ import type { IndexPage } from "../sitemap";
 import Box from "@components/layout/box/box.astro";
 import TextWithIcon from "@components/atom/TextWithIcon.astro";
 import { bachelorPage } from "../sitemap";
+import { bachelorPageEnable } from "src/site.config";
 
 interface Props {
   pages: IndexPage[];
@@ -70,11 +71,14 @@ const lastPage = pages[pages.length - 1];
         </li>
       ))
     }
-    <li class="nav-index strong">
-      <Box p="0.5rem">
-        <a href={bachelorPage.url}>卒研配属情報</a>
-      </Box>
-    </li>
+    {
+      bachelorPageEnable && 
+      <li class="nav-index strong">
+        <Box p="0.5rem">
+          <a href={bachelorPage.url}>卒研配属情報</a>
+        </Box>
+      </li>
+    }
   </ul>
 </nav>
 

--- a/src/layouts/base/parts/header/desktop/Nav.astro
+++ b/src/layouts/base/parts/header/desktop/Nav.astro
@@ -72,12 +72,13 @@ const lastPage = pages[pages.length - 1];
       ))
     }
     {
-      bachelorPageEnable && 
-      <li class="nav-index strong">
-        <Box p="0.5rem">
-          <a href={bachelorPage.url}>卒研配属情報</a>
-        </Box>
-      </li>
+      bachelorPageEnable && (
+        <li class="nav-index strong">
+          <Box p="0.5rem">
+            <a href={bachelorPage.url}>卒研配属情報</a>
+          </Box>
+        </li>
+      )
     }
   </ul>
 </nav>

--- a/src/layouts/base/parts/header/mobile/Nav.astro
+++ b/src/layouts/base/parts/header/mobile/Nav.astro
@@ -13,12 +13,15 @@ interface Props {
 
 <nav id={Astro.props.id}>
   {
-    bachelorPageEnable &&
-    <div class="root">
-      <h2>
-        <a href={bachelorPage.url} class="strong-link">卒研配属情報</a>
-      </h2>
-    </div>
+    bachelorPageEnable && (
+      <div class="root">
+        <h2>
+          <a href={bachelorPage.url} class="strong-link">
+            卒研配属情報
+          </a>
+        </h2>
+      </div>
+    )
   }
 
   {

--- a/src/layouts/base/parts/header/mobile/Nav.astro
+++ b/src/layouts/base/parts/header/mobile/Nav.astro
@@ -3,6 +3,7 @@ import FullscreenNavIndexAcordion from "./NavIndexAcordion.astro";
 import FullscreenNavIndexLink from "./NavIndexLink.astro";
 import type { IndexPage } from "../sitemap";
 import { bachelorPage } from "../sitemap";
+import { bachelorPageEnable } from "src/site.config";
 
 interface Props {
   id?: string;
@@ -11,11 +12,15 @@ interface Props {
 ---
 
 <nav id={Astro.props.id}>
-  <div class="root">
-    <h2>
-      <a href={bachelorPage.url} class="strong-link">卒研配属情報</a>
-    </h2>
-  </div>
+  {
+    bachelorPageEnable &&
+    <div class="root">
+      <h2>
+        <a href={bachelorPage.url} class="strong-link">卒研配属情報</a>
+      </h2>
+    </div>
+  }
+
   {
     Astro.props.sitemap.map((index) => (
       <div>

--- a/src/layouts/base/parts/header/sitemap.ts
+++ b/src/layouts/base/parts/header/sitemap.ts
@@ -1,4 +1,5 @@
 import { getCollection } from "astro:content";
+import { bachelorPageEnable } from "src/site.config";
 
 const latestPubYear = [
   ...new Set(
@@ -46,7 +47,7 @@ export const pages: IndexPage[] = [
     title: "Teams",
     hasChildren: true,
     icon: "material-symbols:team-dashboard-outline",
-    children: [bachelorPage, ...teamPages],
+    children: bachelorPageEnable ? [bachelorPage, ...teamPages] : teamPages,
   },
   {
     title: "Members",
@@ -113,11 +114,13 @@ export const pages: IndexPage[] = [
         url: "https://www.ccs.tsukuba.ac.jp/",
         icon: "material-symbols:arrow-outward-rounded",
       },
-      {
-        title: "卒研配属情報",
-        url: "/bachelor/#!index.md",
-        icon: "material-symbols:arrow-outward-rounded",
-      },
+      ...(bachelorPageEnable ? [
+        {
+          title: "卒研配属情報",
+          url: "/bachelor/#!index.md",
+          icon: "material-symbols:arrow-outward-rounded",
+        }
+      ] : []),
       {
         title: "情報システム実験B",
         url: "/experiment/text.html",

--- a/src/layouts/base/parts/header/sitemap.ts
+++ b/src/layouts/base/parts/header/sitemap.ts
@@ -114,13 +114,15 @@ export const pages: IndexPage[] = [
         url: "https://www.ccs.tsukuba.ac.jp/",
         icon: "material-symbols:arrow-outward-rounded",
       },
-      ...(bachelorPageEnable ? [
-        {
-          title: "卒研配属情報",
-          url: "/bachelor/#!index.md",
-          icon: "material-symbols:arrow-outward-rounded",
-        }
-      ] : []),
+      ...(bachelorPageEnable
+        ? [
+            {
+              title: "卒研配属情報",
+              url: "/bachelor/#!index.md",
+              icon: "material-symbols:arrow-outward-rounded",
+            },
+          ]
+        : []),
       {
         title: "情報システム実験B",
         url: "/experiment/text.html",

--- a/src/pages/bachelor.astro
+++ b/src/pages/bachelor.astro
@@ -16,6 +16,7 @@ import type { InformationSession } from "@content";
 import { bachelorPageEnable } from "src/site.config";
 
 if (!bachelorPageEnable) {
+  // eslint-disable-next-line no-undef
   return new Response(null, { status: 404 });
 }
 

--- a/src/pages/bachelor.astro
+++ b/src/pages/bachelor.astro
@@ -15,8 +15,8 @@ import Session from "@components/pages/bachelor/Session.astro";
 import type { InformationSession } from "@content";
 import { bachelorPageEnable } from "src/site.config";
 
-if(!bachelorPageEnable) {
-  return new Response(null, {status: 404});
+if (!bachelorPageEnable) {
+  return new Response(null, { status: 404 });
 }
 
 const teams = await getCollection("team");

--- a/src/pages/bachelor.astro
+++ b/src/pages/bachelor.astro
@@ -13,6 +13,11 @@ import { getCollection } from "astro:content";
 import H2 from "@components/composite/heading/h2.astro";
 import Session from "@components/pages/bachelor/Session.astro";
 import type { InformationSession } from "@content";
+import { bachelorPageEnable } from "src/site.config";
+
+if(!bachelorPageEnable) {
+  return new Response(null, {status: 404});
+}
 
 const teams = await getCollection("team");
 const generalSession: InformationSession = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,6 +12,7 @@ import NoImgHeader from "@components/composite/header/NoImageHeader.astro";
 import ExternalLink from "@components/atom/link/ExternalLink.astro";
 import { getCollection } from "astro:content";
 import H2 from "@components/composite/heading/h2.astro";
+import { bachelorPageEnable } from "src/site.config";
 
 const news = (await getCollection("news")).sort(
   (a, b) => Date.parse(b.data.date) - Date.parse(a.data.date),
@@ -72,9 +73,12 @@ const carouselPictures = (await getCollection("carousel"))
       これらの大規模並列計算機を用いて各種計算科学応用分野と積極的な関係・共同研究を行っており，
       並列言語・ライブラリ・アルゴリズム等、様々な面で実世界に役立つ高性能計算を目指した研究を進めています．
     </Typography>
-    <H2>
-      <a href="/bachelor" class="large-link">卒研配属情報はこちらから</a>
-    </H2>
+    {
+      bachelorPageEnable &&
+      <H2>
+        <a href="/bachelor" class="large-link">卒研配属情報はこちらから</a>
+      </H2>
+    }
   </TopLevelSection>
   <TopLevelSection backgroundInverted={false}>
     <H2>What's news</H2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -74,10 +74,13 @@ const carouselPictures = (await getCollection("carousel"))
       並列言語・ライブラリ・アルゴリズム等、様々な面で実世界に役立つ高性能計算を目指した研究を進めています．
     </Typography>
     {
-      bachelorPageEnable &&
-      <H2>
-        <a href="/bachelor" class="large-link">卒研配属情報はこちらから</a>
-      </H2>
+      bachelorPageEnable && (
+        <H2>
+          <a href="/bachelor" class="large-link">
+            卒研配属情報はこちらから
+          </a>
+        </H2>
+      )
     }
   </TopLevelSection>
   <TopLevelSection backgroundInverted={false}>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -1,0 +1,2 @@
+// 卒研配属情報ページの有効フラグ
+export const bachelorPageEnable = false;


### PR DESCRIPTION
#413 
卒研配属ページを非表示にしました。  
`src/site.config.ts` の `bachelorPageEnable` を `true` に設定することで再表示できます。  