### PR TITLE
fix(infra): traefik のルーティングに /en/ を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,12 @@ export async function getStaticPaths() {
 ページ内のリンクは `localePath(lang, "/news")` を通してください。
 日本語なら `/news`、英語なら `/en/news` になります。直書きすると英語版から日本語版へ飛んでしまいます。
 
+**トップレベルのパスを増やしたら、traefik のルーティングにも追加してください。**
+`infra/docker-compose.yml` の `traefik.http.routers.web.rule` はパスの明示的な許可リストで、
+ここに載っていないパスは従来の Apache （`fallback` コンテナ）へ流れて 404 になります。
+`/~user` や `/internal` などの旧来のパスを Apache に残すための仕組みなので、
+新しいページを足したときはこのルールの更新を忘れないこと。
+
 ## インフラ（admin向け）
 
 前段が`traefik`でTLS終端を行う。このページ本体のサーブは`nginx`。

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -73,4 +73,6 @@ services:
         || Path(`/publications`)
         || PathPrefix(`/teams/`)
         || Path(`/teams`)
+        || PathPrefix(`/en/`)
+        || Path(`/en`)
         )


### PR DESCRIPTION
traefik の `traefik.http.routers.web.rule` はパスの明示的な許可リストで、 ここに載っていないパスは従来の Apache (fallback コンテナ) へ流れる。
`/en/` を追加していなかったため、英語版ページが全て Apache の 404 になっていた。

`PathPrefix(/en/)` と `Path(/en)` を追加した。これで英語版の全ページが nginx コンテナへ振り分けられる。

同じ落とし穴を繰り返さないよう、トップレベルのパスを増やしたら
このルールも更新する必要があることを README に明記した。
